### PR TITLE
using "su -" instead of su

### DIFF
--- a/autopostgresqlbackup
+++ b/autopostgresqlbackup
@@ -356,9 +356,9 @@ dbdump () {
     for db in $1 ; do
         if [ -n "$SU_USERNAME" ]; then
             if [ "$db" = "$GLOBALS_OBJECTS" ]; then
-                su $SU_USERNAME -l -c "pg_dumpall $PGHOST --globals-only" >> $2
+                su - $SU_USERNAME -l -c "pg_dumpall $PGHOST --globals-only" >> $2
             else
-                su $SU_USERNAME -l -c "pg_dump $PGHOST $OPT $db" >> $2
+                su - $SU_USERNAME -l -c "pg_dump $PGHOST $OPT $db" >> $2
             fi
         else
             if [ "$db" = "$GLOBALS_OBJECTS" ]; then
@@ -453,7 +453,7 @@ fi
 # If backing up all DBs on the server
 if [ "$DBNAMES" = "all" ]; then
     if [ -n "$SU_USERNAME" ]; then
-        DBNAMES="$(su $SU_USERNAME -l -c "LANG=C psql -U $USERNAME $PGHOST -l -A -F: | sed -ne '/:/ { /Name:Owner/d; /template0/d; s/:.*$//; p }'")"
+        DBNAMES="$(su - $SU_USERNAME -l -c "LANG=C psql -U $USERNAME $PGHOST -l -A -F: | sed -ne '/:/ { /Name:Owner/d; /template0/d; s/:.*$//; p }'")"
     else
         DBNAMES="`LANG=C psql -U $USERNAME $PGHOST -l -A -F: | sed -ne "/:/ { /Name:Owner/d; /template0/d; s/:.*$//; p }"`"
     fi


### PR DESCRIPTION
When this script was run from crontab I was getting the error below. It was happening, because `su` does not initialize the environment variables for the user (in this case $HOME). 
Switching to `su -` solved the problem for me.

```
could not change directory to "/root": Permission denied
could not change directory to "/root": Permission denied
could not change directory to "/root": Permission denied
could not change directory to "/root": Permission denied
could not change directory to "/root": Permission denied
could not change directory to "/root": Permission denied
```