### PR TITLE
Use the more portable shebang `/usr/bin/env bash`

### DIFF
--- a/autopostgresqlbackup
+++ b/autopostgresqlbackup
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # {{{ License and Copyright
 # PostgreSQL Backup Script


### PR DESCRIPTION
Not all distros have bash in `/bin/bash`. In fact, most distros are moving binaries away from `/bin` and into `/usr/bin` (even Debian!). But still, not all distros have bash in `/bin` or `/usr/bin`. However, pretty much all of them have `env` in `/usr/bin`. `/usr/bin/env bash` searches `$PATH` for the bash executable, and is the most portable shebang to use.

I.e., on OpenBSD, you find bash in `/usr/bin/local/bash`, and there is no `/bin/bash`, so autopostgresql fails before it even starts.

[`/usr/bin/env bash`](https://bash-prompt.net/guides/bash-portability/) [seems](https://stackoverflow.com/questions/21612980/why-is-usr-bin-env-bash-superior-to-bin-bash) [to](https://stackoverflow.com/questions/16365130/what-is-the-difference-between-usr-bin-env-bash-and-usr-bin-bash) [be](https://askubuntu.com/questions/88257/what-type-of-path-in-shebang-is-more-preferable) [best](https://linuxconfig.org/bash-script-shebang-usage-and-best-practices) [practice](https://en.wikipedia.org/wiki/Shebang_(Unix)#Portability) :).