### PR TITLE
Support pg_dump directory format

### DIFF
--- a/Documentation.md
+++ b/Documentation.md
@@ -266,6 +266,14 @@ Options string for use with pg_dump (see
 [pg_dump](https://www.postgresql.org/docs/current/app-pgdump.html) manual
 page).
 
+If this string contains the option to use the directory dump format of
+pg_dump, the resulting file will be a tarball of the directory that
+pg_dump creates.
+
+Note that by default pg_dump uses gzip zo compress the files it writes
+into this directory. Use the pg_dump option to change this, the COMP
+variable of this script is not used for directory format dumps!
+
 **default**: `""` (empty)
 
 *Only while using PostgreSQL database engine*

--- a/autopostgresqlbackup
+++ b/autopostgresqlbackup
@@ -369,6 +369,10 @@ postgresqldb_dump () {
     local db_name cmd_prog cmd_args pg_args
 
     db_name="${1}"
+    # Only needed here when we use directory format, so only check then
+    if [[ ${PGDUMP_OPTS} =~ (-F|--format=)( d|d)(irectory)? ]]; then
+        dump_file="${2:?Missing dump_file}"
+    fi
 
     if [ -n "${PGDUMP_OPTS}" ]; then
         IFS=" " read -r -a PGDUMP_ARGS <<< "${PGDUMP_OPTS}"
@@ -398,6 +402,9 @@ postgresqldb_dump () {
         if [ "${CREATE_DATABASE}" = "yes" ]; then
             pg_args+=(--create)
         fi
+	if [[ ${PGDUMP_OPTS} =~ (-F|--format=)( d|d)(irectory)? ]]; then
+	    pg_args+=(--file "${dump_file}")
+	fi
     fi
 
     if [ "${#CONN_ARGS[@]}" -gt 0 ]; then
@@ -564,7 +571,7 @@ db_list () {
 db_dump () {
     case ${DBENGINE} in
         postgresql|mysql)
-            ${DBENGINE}db_dump "${1}"
+            ${DBENGINE}db_dump "${1}" "${2:-}"
             ;;
         *)
             log_error "Unsupported database engine ${DBENGINE}, check DBENGINE configuration parameter"
@@ -631,7 +638,15 @@ dump() {
         dump_file="${dump_file}${ENCRYPTION_SUFFIX}"
     fi
 
-    if [ -n "${COMP}" ] && [ "${ENCRYPTION}" = "yes" ]; then
+    if [[ ${PGDUMP_OPTS} =~ (-F|--format=)( d|d)(irectory)? ]]; then
+	log_debug "Dumping (${db_name}) using directory format to '${dump_file}'"
+	db_dump "${db_name}" "${dump_file}"
+	# Now move everything into one tarfile, so the one-file-per-backup assumption holds true
+	# Name it with a .tar, as the final name (${dump_file}) exists as a directory entry
+	tar --directory $(dirname "${dump_file}") --transform "s/.${EXT}${comp_ext}//" --create --remove-files "$(basename "${dump_file}")" > "${dump_file}.tar"
+	# And now rename to the expected filename for the backup.
+	mv "${dump_file}.tar" "${dump_file}"
+    elif [ -n "${COMP}" ] && [ "${ENCRYPTION}" = "yes" ]; then
         log_debug "Dumping (${db_name}) +compress +encrypt to '${dump_file}'"
         db_dump "${db_name}" | compression | encryption > "${dump_file}"
     elif [ -n "${COMP}" ]; then

--- a/autopostgresqlbackup
+++ b/autopostgresqlbackup
@@ -370,7 +370,7 @@ postgresqldb_dump () {
 
     db_name="${1}"
     # Only needed here when we use directory format, so only check then
-    if [[ ${PGDUMP_OPTS} =~ (-F|--format=)( d|d)(irectory)? ]]; then
+    if [[ ${db_name} != "${GLOBALS_OBJECTS}" ]] && [[ ${PGDUMP_OPTS} =~ (-F|--format=)( d|d)(irectory)? ]]; then
         dump_file="${2:?Missing dump_file}"
     fi
 
@@ -638,7 +638,7 @@ dump() {
         dump_file="${dump_file}${ENCRYPTION_SUFFIX}"
     fi
 
-    if [[ ${PGDUMP_OPTS} =~ (-F|--format=)( d|d)(irectory)? ]]; then
+    if [[ ${db_name} != "${GLOBALS_OBJECTS}" ]] && [[ ${PGDUMP_OPTS} =~ (-F|--format=)( d|d)(irectory)? ]]; then
 	log_debug "Dumping (${db_name}) using directory format to '${dump_file}'"
 	db_dump "${db_name}" "${dump_file}"
 	# Now move everything into one tarfile, so the one-file-per-backup assumption holds true


### PR DESCRIPTION
pg_dump has an export mode to write into a directory - and do multi-process dumps, but that needs the dump target to be a directory, not a file.
So we dump into a directory - and then use tar to "morph" the directory to a file, which is what autopostgresqlbackup expects.

We do not use compression for the tarball itself, even if COMP is set -> all the files are already compressed by pg_dump, running our own comp on top will not gain anything.
Also, compression of pg_dump defaults to gzip. To change it we use the pg_dump option within the PGDUMP_OPTS variable (I recommend zstd, level 9), not touching COMP, as that makes handling much easier. We can't use the way autopostgresqlbackup usually does compression anyways.

This should close: #23 
